### PR TITLE
Update gh action to run on on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'If set, A MS Teams notification will be sent to this webhook'
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: 'message-circle'  


### PR DESCRIPTION
Run gh action on node16 instead of node12.
From:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/